### PR TITLE
Added fallback when the 'areas' key does not exist in LocalStorage

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -12,7 +12,15 @@ if (process.platform === 'darwin') {
   app.dock.hide()
 }
 let appIcon = null
-const areas = JSON.parse(ls.getItem('areas'))
+
+const areasJson = ls.getItem('areas')
+let areas = null
+if (areasJson){
+    areas = JSON.parse(areasJson)
+}else{
+    var allAreas = require('./data/areas.json')
+    areas = [allAreas[0]]
+}
 
 const areaNameClick = (areaName) => {
   return () => {

--- a/app/app.js
+++ b/app/app.js
@@ -71,6 +71,12 @@ const updateMenu = () => {
     } else {
       appIcon.setImage(`${__dirname}/data/img/sun.png`)
     }
+  }).catch((error) =>{
+    console.error(error)
+    menuItems.push({label: 'Caught error'})
+    menuItems.push({type: 'normal', label: 'quit', click: app.quit})
+    const _m = Menu.buildFromTemplate(menuItems)
+    appIcon.setContextMenu(_m)
   })
 }
 


### PR DESCRIPTION
At the first launch, the app shows neither a status icon nor an error message.
There are two reasons and this PR fixes them.

First, there are no ``catch `` for ``forEachPromise``.
So, if it fails, nothing will be happen.
41a9f04 fixes it.

Second, if the 'areas' key does not exist in LocalStorage, ``JSON.parse`` fails. 
0855bbb added fallback to use an area in ``areas.json`` in the case. 

Than you for your nice app!